### PR TITLE
Display the room version

### DIFF
--- a/mxclient/room-state.go
+++ b/mxclient/room-state.go
@@ -40,6 +40,7 @@ type RoomState struct {
 	Topic          string
 	Name           string
 	canonicalAlias string
+	roomVersion    string
 	AvatarURL      MXCURL
 	aliasMap       map[string][]string
 	Aliases        RoomAliases
@@ -100,6 +101,9 @@ func (rs *RoomState) UpdateOnEvent(event *gomatrix.Event, usePrevContent bool) {
 	case "m.room.create":
 		if creator, ok := event.Content["creator"].(string); ok {
 			rs.Creator = creator
+		}
+		if roomVer, ok := event.Content["room_version"].(string); ok {
+			rs.roomVersion = roomVer
 		}
 	case "m.room.join_rules": // We do not (yet) care about m.room.join_rules
 	case "m.room.member":

--- a/mxclient/room.go
+++ b/mxclient/room.go
@@ -26,6 +26,7 @@ type RoomInfo struct {
 	Name            string
 	CanonicalAlias  string
 	Topic           string
+	RoomVersion     string
 	AvatarURL       MXCURL
 	NumMemberEvents int
 	NumMembers      int
@@ -223,6 +224,7 @@ func (r *Room) RoomInfo() RoomInfo {
 		r.latestRoomState.CalculateName(),
 		r.latestRoomState.canonicalAlias,
 		r.latestRoomState.Topic,
+		r.latestRoomState.roomVersion,
 		r.latestRoomState.AvatarURL,
 		r.latestRoomState.GetNumMemberEvents(),
 		r.latestRoomState.NumMembers(),

--- a/templates/room-chat.qtpl
+++ b/templates/room-chat.qtpl
@@ -382,5 +382,6 @@
     <hr>
 
     <a href="./">Back to Room List</a>
+    <span style="float: right;">Room Version: {% space %}{%s p.RoomInfo.RoomVersion %}</span>
 {% endfunc %}
 {% endstripspace %}


### PR DESCRIPTION
I often find myself needing to determine what room version is being used and I don't want to have to join the room to do that. This PR which shows the room version at the bottom of the screen. If there was a room details page I would have put it there but I think this is probably a fine location for it until something like that exists.

<img width="1046" src="https://user-images.githubusercontent.com/5855073/140635069-8448dda9-0eb7-40b6-9d1f-89b1ab2a3c7c.png">