### PR TITLE
Remove redundant image alt attribute

### DIFF
--- a/templates/room-memberinfo.qtpl
+++ b/templates/room-memberinfo.qtpl
@@ -32,10 +32,10 @@
             <td>
                 {% if p.MemberInfo.AvatarURL.IsValid() %}
                     <a href="{%s p.MemberInfo.AvatarURL.ToURL() %}">
-                        <img class="avatar userAvatarBig" src="{%s p.MemberInfo.AvatarURL.ToThumbURL(48, 48, "crop") %}" alt="{%s p.MemberInfo.MXID %}" />
+                        <img class="avatar userAvatarBig" src="{%s p.MemberInfo.AvatarURL.ToThumbURL(48, 48, "crop") %}" alt="" />
                     </a>
                 {% else %}
-                    <img class="avatar userAvatarBig" src="./avatar/{%u p.MemberInfo.GetName() %}" alt="{%s p.MemberInfo.MXID %}" />
+                    <img class="avatar userAvatarBig" src="./avatar/{%u p.MemberInfo.GetName() %}" alt="" />
                 {% endif %}
             </td>
         </tr>

--- a/templates/room-servers.qtpl
+++ b/templates/room-servers.qtpl
@@ -14,7 +14,7 @@
 {% stripspace %}
 {% func (p *RoomServersPage) printServer(server mxclient.ServerUserCount) %}
     <tr>
-        <td><img class="avatar serverAvatar" src="./avatar/{%u server.ServerName %}" alt="{%s server.ServerName %}" /> {%s server.ServerName %}</td>
+        <td><img class="avatar serverAvatar" src="./avatar/{%u server.ServerName %}" alt="" /> {%s server.ServerName %}</td>
         <td>{%d server.NumUsers %}</td>
     </tr>
 {% endfunc %}


### PR DESCRIPTION
When the image is present next to text, repeating the text in the alt=
makes tools reading the alt (screen reader, clipboard, ...) to repeat the
text