### PR TITLE
Remove room ids from alt attributes

### DIFF
--- a/mxclient/room-state.go
+++ b/mxclient/room-state.go
@@ -40,6 +40,7 @@ type RoomState struct {
 	Topic          string
 	Name           string
 	canonicalAlias string
+	roomVersion    string
 	AvatarURL      MXCURL
 	aliasMap       map[string][]string
 	Aliases        RoomAliases
@@ -100,6 +101,9 @@ func (rs *RoomState) UpdateOnEvent(event *gomatrix.Event, usePrevContent bool) {
 	case "m.room.create":
 		if creator, ok := event.Content["creator"].(string); ok {
 			rs.Creator = creator
+		}
+		if roomVer, ok := event.Content["room_version"].(string); ok {
+			rs.roomVersion = roomVer
 		}
 	case "m.room.join_rules": // We do not (yet) care about m.room.join_rules
 	case "m.room.member":

--- a/mxclient/room.go
+++ b/mxclient/room.go
@@ -26,6 +26,7 @@ type RoomInfo struct {
 	Name            string
 	CanonicalAlias  string
 	Topic           string
+	RoomVersion     string
 	AvatarURL       MXCURL
 	NumMemberEvents int
 	NumMembers      int
@@ -223,6 +224,7 @@ func (r *Room) RoomInfo() RoomInfo {
 		r.latestRoomState.CalculateName(),
 		r.latestRoomState.canonicalAlias,
 		r.latestRoomState.Topic,
+		r.latestRoomState.roomVersion,
 		r.latestRoomState.AvatarURL,
 		r.latestRoomState.GetNumMemberEvents(),
 		r.latestRoomState.NumMembers(),

--- a/templates/room-chat.qtpl
+++ b/templates/room-chat.qtpl
@@ -382,5 +382,6 @@
     <hr>
 
     <a href="./">Back to Room List</a>
+    <span style="float: right;">Room Version: {% space %}{%s p.RoomInfo.RoomVersion %}</span>
 {% endfunc %}
 {% endstripspace %}

--- a/templates/room-common.qtpl
+++ b/templates/room-common.qtpl
@@ -8,14 +8,14 @@
         <tr>
             <td class="roomAvatar" rowspan="2">
                 {% if roomInfo.AvatarURL.IsValid() %}
-                    <img class="avatar roomAvatar" src="{%s roomInfo.AvatarURL.ToThumbURL(64, 64, "crop") %}" alt="{%s roomInfo.RoomID %}" />
+                    <img class="avatar roomAvatar" src="{%s roomInfo.AvatarURL.ToThumbURL(64, 64, "crop") %}" alt="" />
                 {% else %}
                     {% if roomInfo.Name != "" %}
-                        <img class="avatar roomAvatar" src="./avatar/{%u roomInfo.Name %}" alt="{%s roomInfo.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./avatar/{%u roomInfo.Name %}" alt="" />
                     {% elseif roomInfo.CanonicalAlias != "" %}
-                        <img class="avatar roomAvatar" src="./avatar/{%u roomInfo.CanonicalAlias %}" alt="{%s roomInfo.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./avatar/{%u roomInfo.CanonicalAlias %}" alt="" />
                     {% else %}
-                        <img class="avatar roomAvatar" src="./img/logo_missing.png" alt="{%s roomInfo.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./img/logo_missing.png" alt="" />
                     {% endif %}
                 {% endif %}
             </td>

--- a/templates/rooms.qtpl
+++ b/templates/rooms.qtpl
@@ -35,14 +35,14 @@
         <td>
             <a href="./room/{%s Room.RoomID %}/">
                 {% if Room.AvatarURL != "" %}
-                    <img class="avatar roomAvatar" src="{%s Room.AvatarURL %}" alt="{%s Room.RoomID %}" />
+                    <img class="avatar roomAvatar" src="{%s Room.AvatarURL %}" alt="" />
                 {% else %}
                     {% if Room.Name != "" %}
-                        <img class="avatar roomAvatar" src="./avatar/{%u Room.Name %}" alt="{%s Room.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./avatar/{%u Room.Name %}" alt="" />
                     {% elseif Room.CanonicalAlias != "" %}
-                        <img class="avatar roomAvatar" src="./avatar/{%u Room.CanonicalAlias %}" alt="{%s Room.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./avatar/{%u Room.CanonicalAlias %}" alt="" />
                     {% else %}
-                        <img class="avatar roomAvatar" src="./img/logo_missing_transparent.png" alt="{%s Room.RoomID %}" />
+                        <img class="avatar roomAvatar" src="./img/logo_missing_transparent.png" alt="" />
                     {% endif %}
                 {% endif %}
             </a>


### PR DESCRIPTION
By definition, alt= attributes are meant to be human-readable, and
room IDs are meant not to be.